### PR TITLE
Reduce wet effects on morale to reasonable levels

### DIFF
--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1926,9 +1926,9 @@ void Character::apply_wetness_morale( int temperature )
         }
 
         // For an unmutated human swimming in deep water, this will add up to:
-        // +51 when hot in 100% water friendly clothing
-        // -103 when cold/hot in 100% unfriendly clothing
-        total_morale += static_cast<int>( bp_morale * ( 1.0 + scaled_temperature ) / 2.0 );
+        // +12 when hot in 100% water friendly clothing
+        // -26 when cold/hot in 100% unfriendly clothing
+        total_morale += static_cast<int>( bp_morale * ( 1.0 + scaled_temperature ) / 8.0 );
     }
 
     if( total_morale == 0 ) {


### PR DESCRIPTION
#### Summary

SUMMARY: Balance "Reduce wet effects on morale to reasonable levels"

#### Purpose of change
Overall, wet effects in game seem quite intolerable. You stand in some puddlr for a single moment and now you are too depressed to even read a jovial book. As a result, I have decided to reduce the affects of water and its dastardly effects upon the player.


#### Describe the solution

Simply put, being wet now no longer makes you questioning your existence.

#### Describe alternatives you've considered

Mermaids must've infiltrated the development team to convince us landgrubbers to despise their watery home or something because I can't exactly see how water constitutes such drastic influences on someone's morale.

#### Testing

Beep boop, some simple number changes, that's all.

#### Additional context

Stay hydrated!